### PR TITLE
Update Android.mk

### DIFF
--- a/healthd/Android.mk
+++ b/healthd/Android.mk
@@ -45,9 +45,9 @@ endif
 
 LOCAL_HAL_STATIC_LIBRARIES := libhealthd
 
-# Symlink /charger to /sbin/healthd
+# Symlink /charger to sbin/healthd
 LOCAL_POST_INSTALL_CMD := $(hide) mkdir -p $(TARGET_ROOT_OUT) \
-    && ln -sf /sbin/healthd $(TARGET_ROOT_OUT)/charger
+    && ln -sf sbin/healthd $(TARGET_ROOT_OUT)/charger
 
 include $(BUILD_EXECUTABLE)
 


### PR DESCRIPTION
We don't have "/sbin/healthd" path in recovery and your symlink is broken
we have "sbin/healthd" path
