### PR TITLE
Add /sbin to ld search paths

### DIFF
--- a/rootdir/etc/ld.config.legacy.txt
+++ b/rootdir/etc/ld.config.legacy.txt
@@ -19,6 +19,7 @@ namespace.default.isolated = false
 namespace.default.search.paths  = /system/${LIB}
 namespace.default.search.paths += /vendor/${LIB}
 namespace.default.search.paths += /odm/${LIB}
+namespace.default.search.paths += /sbin
 
 namespace.default.asan.search.paths  = /data/asan/system/${LIB}
 namespace.default.asan.search.paths +=           /system/${LIB}


### PR DESCRIPTION
This change is required to fix a linker issue on the Samsung Galaxy Fold and likely other devices.

The following error was caused by the ld.config.txt changes and this commit resolves that issue.

```
CANNOT LINK EXECUTABLE "/sbin/sh": library "libc++.so" not found
linker: CANNOT LINK EXECUTABLE "/sbin/sh": library "libc++.so" not found
```